### PR TITLE
Dummy authentication backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,10 @@ header contains a prefix (typically Token) followed by an `API Token`
 
 Token based authentication using the `JSON Web Token standard <https://jwt.io/introduction/>`__
 
++ **Dummy Authentication**
+
+Backend which does not perform any authentication checks
+
 + **Multi Backend Authentication**
 
 A Backend which comprises of multiple backends and requires any of them to authenticate
@@ -152,6 +156,9 @@ API
     :members:
 
 .. autoclass:: falcon_auth.JWTAuthBackend
+    :members:
+
+.. autoclass:: falcon_auth.NoneAuthBackend
     :members:
 
 .. autoclass:: falcon_auth.MultiAuthBackend

--- a/falcon_auth/__init__.py
+++ b/falcon_auth/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
 
 from .backends import TokenAuthBackend, BasicAuthBackend, \
-    JWTAuthBackend, MultiAuthBackend
+    JWTAuthBackend, NoneAuthBackend, MultiAuthBackend
 from .middleware import FalconAuthMiddleware

--- a/falcon_auth/backends.py
+++ b/falcon_auth/backends.py
@@ -386,6 +386,26 @@ class TokenAuthBackend(BasicAuthBackend):
             auth_header_prefix=self.auth_header_prefix, token=token)
 
 
+class NoneAuthBackend(AuthBackend):
+    """
+    Dummy authentication backend.
+
+    This backend does not perform any authentication check. It can be used with the
+    MultiAuthBackend in order to provide a fallback for an unauthenticated user.
+
+    Args:
+        user_loader(function, required): A callback function that is called
+            without any arguments and returns an `unauthenticated user`.
+
+    """
+
+    def __init__(self, user_loader):
+        self.user_loader = user_loader
+
+    def authenticate(self, req, resp, resource):
+        return self.user_loader()
+
+
 class MultiAuthBackend(AuthBackend):
 
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 from falcon import testing
 
 from falcon_auth.backends import BasicAuthBackend, JWTAuthBackend, \
-    MultiAuthBackend
+    NoneAuthBackend, MultiAuthBackend
 from falcon_auth.middleware import FalconAuthMiddleware
 from falcon_auth.backends import TokenAuthBackend
 
@@ -54,6 +54,11 @@ class User(object):
 @pytest.fixture(scope='function')
 def user():
     return User(_id=1, username='joe', password='pass')
+
+
+@pytest.fixture(scope='function')
+def none_user():
+    return User(_id=0, username='anonymous', password=None)
 
 
 def create_app(auth_middleware, resource):
@@ -169,6 +174,18 @@ class JWTAuthFixture:
     def auth_token(self, user):
 
         return get_jwt_token(user)
+
+
+@pytest.fixture(scope='function')
+def none_backend(none_user):
+    return NoneAuthBackend(lambda: none_user)
+
+
+class NoneAuthFixture:
+
+    @pytest.fixture(scope='function')
+    def backend(self, none_user):
+        return none_backend(none_user)
 
 
 class MultiBackendAuthFixture:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -144,6 +144,14 @@ class TestWithJWTAuth(JWTAuthFixture, ResourceFixture):
         assert 'Issuer parameter must be provided' in str(ex.value)
 
 
+class TestWithNoneAuth(NoneAuthFixture, ResourceFixture):
+
+    def test_valid_auth_success(self, client, none_user):
+        resp = simulate_request(client, '/auth')
+        assert resp.status_code == 200
+        assert resp.json == none_user.to_dict()
+
+
 class TestWithMultiBackendAuth(MultiBackendAuthFixture, ResourceFixture):
     def test_valid_auth_success_any_backend(self, client, user):
         basic_auth_token = get_basic_auth_token(user.username, user.password)


### PR DESCRIPTION
If one needs to create a REST endpoint which will authenticate against multiple mechanisms (backends), this can be achieved with the MultiAuthBackend. Great! However, if such an endpoint should also allow an anonymous access... it seems that right now it is not possible.

In order to allow such a scenario, I've created a dummy authentication backend. This backend can be used to provide consistent user API for an authenticated and an unauthenticated user. One might use it as follows:

```python
backend = MultiAuthBackend(
  TokenAuthBackend(lambda token: load_authenticated_user(token)),
  NoneAuthBackend(lambda: load_unauthenticated_user()))
api = falcon.API(middleware=[FalconAuthMiddleware(backend)])

class ApiResource:
  def on_post(self, req, resp):
    ... # perform something ordinary
    if req.context['user'].check_permission('vip'):
      ... # perform something extra
```