### PR TITLE
allow non HTTPUnauthorized errors to bubble up

### DIFF
--- a/falcon_auth/backends.py
+++ b/falcon_auth/backends.py
@@ -435,7 +435,7 @@ class MultiAuthBackend(AuthBackend):
                 user = backend.authenticate(req, resp, resource)
                 if user:
                     return user
-            except Exception:
+            except falcon.HTTPUnauthorized:
                 pass
 
         raise falcon.HTTPUnauthorized(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,23 +188,25 @@ class NoneAuthFixture:
         return none_backend(none_user)
 
 
+class CustomException(Exception):
+    pass
+
+
 class MultiBackendAuthFixture:
-
-    class ErroBackend(AuthBackend):
-
+    class ErrorBackend(AuthBackend):
         def __init__(self, user_loader=None):
             pass
 
         def authenticate(self, req, resp, resource):
             if req.get_param_as_bool('exception'):
-                raise falcon.HTTPInternalServerError('A custom error occured.')
+                raise CustomException
             else:
                 raise falcon.HTTPUnauthorized
 
     @pytest.fixture(scope='function')
     def backend(self, basic_auth_backend, token_backend):
         return MultiAuthBackend(
-            self.ErroBackend(),
+            self.ErrorBackend(),
             basic_auth_backend,
             token_backend,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,8 @@ import jwt
 import pytest
 from falcon import testing
 
-from falcon_auth.backends import BasicAuthBackend, JWTAuthBackend, \
-    NoneAuthBackend, MultiAuthBackend
+from falcon_auth.backends import AuthBackend, BasicAuthBackend, \
+    JWTAuthBackend, NoneAuthBackend, MultiAuthBackend
 from falcon_auth.middleware import FalconAuthMiddleware
 from falcon_auth.backends import TokenAuthBackend
 
@@ -190,9 +190,24 @@ class NoneAuthFixture:
 
 class MultiBackendAuthFixture:
 
+    class ErroBackend(AuthBackend):
+
+        def __init__(self, user_loader=None):
+            pass
+
+        def authenticate(self, req, resp, resource):
+            if req.get_param_as_bool('exception'):
+                raise falcon.HTTPInternalServerError('A custom error occured.')
+            else:
+                raise falcon.HTTPUnauthorized
+
     @pytest.fixture(scope='function')
     def backend(self, basic_auth_backend, token_backend):
-        return MultiAuthBackend(basic_auth_backend, token_backend)
+        return MultiAuthBackend(
+            self.ErroBackend(),
+            basic_auth_backend,
+            token_backend,
+        )
 
 
 class ResourceFixture:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -177,10 +177,9 @@ class TestWithMultiBackendAuth(MultiBackendAuthFixture, ResourceFixture):
 
     def test_backend_raises_exception(self, client, user, backend):
         auth_token = get_basic_auth_token('Invalid', 'Invalid')
-        resp = simulate_request(client, '/auth', auth_token=auth_token,
-                                query_string='exception=True')
-        assert resp.status_code == 500
-        assert 'A custom error occured' in resp.text
+        with pytest.raises(CustomException):
+            resp = simulate_request(client, '/auth', auth_token=auth_token,
+                                    query_string='exception=True')
 
 
 class TestWithExemptRoute(BasicAuthFixture, ResourceFixture):


### PR DESCRIPTION
MultiAuthBackend was swallowing all exceptions and raising
HTTPUnauthorized.  This is inconsistent with the other backends which
correctly bubbles up unexpected exceptions.