### PR TITLE
Support Falcon uri templates in exempt_routes

### DIFF
--- a/falcon_auth/backends.py
+++ b/falcon_auth/backends.py
@@ -248,13 +248,13 @@ class JWTAuthBackend(AuthBackend):
         if self.audience is not None:
             payload['aud'] = self.audience
 
-        if self.audience is not None:
+        if self.issuer is not None:
             payload['iss'] = self.issuer
 
         return jwt.encode(
             payload,
-            self.secret_key, 
-            algorithm=self.algorithm, 
+            self.secret_key,
+            algorithm=self.algorithm,
             json_encoder=ExtendedJSONEncoder).decode('utf-8')
 
 

--- a/falcon_auth/middleware.py
+++ b/falcon_auth/middleware.py
@@ -57,7 +57,7 @@ class FalconAuthMiddleware(object):
 
     def process_resource(self, req, resp, resource, *args, **kwargs):
         auth_setting = self._get_auth_settings(req, resource)
-        if (req.path in auth_setting['exempt_routes'] or
+        if (req.uri_template in auth_setting['exempt_routes'] or
             req.method in auth_setting['exempt_methods']):
             return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,7 @@ def create_app(auth_middleware, resource):
     api = falcon.API(middleware=[auth_middleware])
 
     api.add_route('/auth', resource)
+    api.add_route('/posts/{post_id}', resource)
     return api
 
 
@@ -86,7 +87,7 @@ class AuthResource:
         user = req.context['user']
         resp.body = user.serialize()
 
-    def on_get(self, req, resp):
+    def on_get(self, req, resp, **kwargs):
         resp.body = 'Success'
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -237,9 +237,15 @@ class TestWithMultiBackendAuth(MultiBackendAuthFixture, ResourceFixture):
 
 
 class TestWithExemptRoute(BasicAuthFixture, ResourceFixture):
-    def test_no_auth_required(self, auth_middleware, client):
+    def test_exempt_static_route(self, auth_middleware, client):
         auth_middleware.exempt_routes = ['/auth']
         resp = simulate_request(client, '/auth', method='GET')
+        assert resp.status_code == 200
+        assert resp.text == 'Success'
+
+    def test_exempt_template_route(self, auth_middleware, client):
+        auth_middleware.exempt_routes = ['/posts/{post_id}']
+        resp = simulate_request(client, '/posts/1234', method='GET')
         assert resp.status_code == 200
         assert resp.text == 'Success'
 


### PR DESCRIPTION
This updates `process_resource()` to use the `req.uri_template` when checking
against the `exempt_routes` configuration. This allows one to exempt templated
routes rather than just hard-coded, static ones.

Addresses loanzen/falcon-auth#11