### PR TITLE
Add more effective multi-auth backend tests

### DIFF
--- a/falcon_auth/backends.py
+++ b/falcon_auth/backends.py
@@ -490,6 +490,8 @@ class HawkAuthBackend(AuthBackend):
             raise falcon.HTTPUnauthorized(
                 description='Invalid User')
 
+        return user
+
 
 class MultiAuthBackend(AuthBackend):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,6 @@ description-file = README.md
 
 [aliases]
 test = pytest
+
+[tool:pytest]
+; addopts = --pdb -x

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import sys
 from setuptools import setup
 
-version = '2.0.0'
+version = '2.0.1'
 
 if sys.argv[-1] == 'tag':
     os.system("git tag -a %s -m 'version %s'" % (version, version))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,11 +265,13 @@ class MultiBackendAuthFixture:
                 raise falcon.HTTPUnauthorized
 
     @pytest.fixture(scope='function')
-    def backend(self, basic_auth_backend, token_backend):
+    def backend(self, basic_auth_backend, token_backend, hawk_backend, jwt_backend):
         return MultiAuthBackend(
             self.ErrorBackend(),
             basic_auth_backend,
             token_backend,
+            hawk_backend,
+            jwt_backend,
         )
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -227,13 +227,26 @@ class TestWithNoneAuth(NoneAuthFixture, ResourceFixture):
 
 
 class TestWithMultiBackendAuth(MultiBackendAuthFixture, ResourceFixture):
-    def test_valid_auth_success_any_backend(self, client, user):
+    def test_valid_auth_success_basic_backend(self, client, user):
         basic_auth_token = get_basic_auth_token(user.username, user.password)
         resp = simulate_request(client, '/auth', auth_token=basic_auth_token)
         assert resp.status_code == 200
         assert resp.json == user.to_dict()
 
+    def test_valid_auth_success_token_backend(self, client, user):
         auth_token = get_token_auth(user)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 200
+        assert resp.json == user.to_dict()
+
+    def test_valid_auth_success_hawk_backend(self, client, user):
+        auth_token = get_hawk_token(user)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 200
+        assert resp.json == user.to_dict()
+
+    def test_valid_auth_success_jwt_backend(self, client, user):
+        auth_token = get_jwt_token(user)
         resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 200
         assert resp.json == user.to_dict()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -225,7 +225,8 @@ class TestWithNoneAuth(NoneAuthFixture, ResourceFixture):
         assert resp.status_code == 200
         assert resp.json == none_user.to_dict()
 
-
+@hawk_available
+@jwt_available
 class TestWithMultiBackendAuth(MultiBackendAuthFixture, ResourceFixture):
     def test_valid_auth_success_basic_backend(self, client, user):
         basic_auth_token = get_basic_auth_token(user.username, user.password)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -229,8 +229,8 @@ class TestWithNoneAuth(NoneAuthFixture, ResourceFixture):
 @jwt_available
 class TestWithMultiBackendAuth(MultiBackendAuthFixture, ResourceFixture):
     def test_valid_auth_success_basic_backend(self, client, user):
-        basic_auth_token = get_basic_auth_token(user.username, user.password)
-        resp = simulate_request(client, '/auth', auth_token=basic_auth_token)
+        auth_token = get_basic_auth_token(user.username, user.password)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 200
         assert resp.json == user.to_dict()
 
@@ -242,9 +242,8 @@ class TestWithMultiBackendAuth(MultiBackendAuthFixture, ResourceFixture):
 
     def test_valid_auth_success_hawk_backend(self, client, user):
         auth_token = get_hawk_token(user)
-        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        resp = simulate_request(client, '/auth', method='GET', auth_token=auth_token)
         assert resp.status_code == 200
-        assert resp.json == user.to_dict()
 
     def test_valid_auth_success_jwt_backend(self, client, user):
         auth_token = get_jwt_token(user)


### PR DESCRIPTION
Exercise each of the backends through the MultiAuthBackend to ensure they're adhering to
the expected contract.

This also fixes a bug in the Hawk backend where the request would pass authentication, but
the `user` object would not be added to `req.context`.