### PR TITLE
[Breaking Changes] Improve MultiAuthBackend behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,14 @@ user to the ``request context``
     class ApiResource:
 
         def on_post(self, req, resp):
+            # req.context['auth'] is of the form:
+            #
+            #   {
+            #       'backend': <backend instance that performed the authentication>,
+            #       'user': <user object retrieved from user_loader()>,
+            #       '<backend-specific-item>': <some extra data from the backend>,
+            #       ...
+            #   }
             user = req.context['auth']['user']
             resp.body = "User Found: {}".format(user['username'])
 
@@ -107,17 +115,24 @@ Disable Authentication for a specific resource
         }
 
 
-Accessing Authenticated User
+Accessing Authenticated User (and other artifacts)
 ----------------------------
-Once the middleware authenticates
-the request using the specified authentication backend, it add the authenticated
-user to the `request context`
+Once the middleware authenticates the request using the specified authentication
+backend, it adds the authenticated user to the `request context`.
 
 .. code:: python
 
     class ApiResource:
 
         def on_post(self, req, resp):
+            # req.context['auth'] is of the form:
+            #
+            #   {
+            #       'backend': <backend instance that performed the authentication>,
+            #       'user': <user object retrieved from user_loader()>,
+            #       '<backend-specific-item>': <some extra data from the backend>,
+            #       ...
+            #   }
             user = req.context['auth']['user']
             resp.body = "User Found: {}".format(user['username'])
 
@@ -150,13 +165,14 @@ If you wish to use this backend, be sure to add the optional dependency to your 
 
 Token based authentication using the `Hawk "Holder-Of-Key Authentication Scheme" <https://github.com/hueniverse/hawk>`__
 If you wish to use this backend, be sure to add the optional dependency to your requirements
-(See Python `"extras" <https://www.python.org/dev/peps/pep-0508/#extras>`__): This backend will
-also provide the ``mohawk.Receiver`` object in the ``req.context['auth']`` result.
+(See Python `"extras" <https://www.python.org/dev/peps/pep-0508/#extras>`__):
 
 .. code:: text
 
     falcon-auth[backend-hawk]
 
+This backend will also provide the ``mohawk.Receiver`` object in the ``req.context['auth']``
+result under the 'receiver' key.
 
 + **Dummy Authentication**
 
@@ -164,8 +180,8 @@ Backend which does not perform any authentication checks
 
 + **Multi Backend Authentication**
 
-A Backend which comprises of multiple backends and requires any of them to authenticate
-the request successfully.
+An ``AuthBackend`` which is comprised of multiple backends and requires any of them to
+authenticate the request successfully.
 
 This backend will iterate over all provided backends until one of the following occurs:
 
@@ -191,7 +207,7 @@ Here are the guidelines to follow when writing your backend:
 - Take care to call the base class ``AuthBackend.__init__(user_loader)`` from your `__init__()`
   method
 - Return a dictionary from `authenticate()` which includes at least the `'user'` key holding
-  the user object returned from ``user_loader()``. Other backend-specific keys can be included
+  the user object returned from ``user_loader()``. Other backend-specific items can be included
   as well.
 - Raise a `BackendNotApplicable` exception if the backend determines that it is not
   equipped to handle the request and should defer to a more appropriate backend.
@@ -204,7 +220,9 @@ Tests
 This library comes with a good set of tests which are included in ``tests/``. To run
 install ``pytest`` and simply invoke ``py.test`` or ``python setup.py test``
 to exercise the tests. You can check the test coverage by running
-``py.test --cov falcon_auth``
+``py.test --cov falcon_auth``. **Note:** The test suite makes use of pytest functionality
+that was deprecated in pytest==4.0.0, so be sure to run tests in an environment that
+uses a prior version.
 
 API
 ----

--- a/falcon_auth/middleware.py
+++ b/falcon_auth/middleware.py
@@ -5,21 +5,21 @@ from __future__ import division
 
 import falcon
 
-from falcon_auth.backends import AuthBackend
+from falcon_auth.backends import AuthBackend, BackendAuthenticationFailure
 
 
 class FalconAuthMiddleware(object):
 
     """
     Creates a falcon auth middleware that uses given authentication backend, and some
-    optinal configuration to authenticate requests. After initializing the
+    optional configuration to authenticate requests. After initializing the
     authentication backend globally you can override the backend as well as
-    other configuration for a particular  resource by setting the `auth` attribute
+    other configuration for a particular resource by setting the `auth` attribute
     on it to an instance of this class.
 
     The authentication backend must return an authenticated user which is then
-    set as `request.context.user` to be used further down by resources othewise
-    an `falcon.HTTPUnauthorized` exception is raised.
+    set as ``request.context['auth']['user']`` to be used further down by resources
+    othewise an ``falcon.HTTPUnauthorized`` exception is raised.
 
     Args:
         backend(:class:`falcon_auth.backends.AuthBackend`, required): Specifies the auth
@@ -32,29 +32,40 @@ class FalconAuthMiddleware(object):
             authentication. Default is ``['OPTIONS']``
 
         context_key(str, optional): The key to be used when adding the successful
-            authentication results to the req.context dictionary. Default is ``'auth'``.
+            authentication results to the ``req.context`` dictionary. Default is ``'auth'``.
 
+        on_success(function, optional): A callback function that is called with the
+            results of the ``authenticate()`` call when authentication succeeds.
+
+            .. code:: python
+
+                def on_success(req, resp, resource, results):
+                    ...
+
+        on_failure(function, optional): A callback function that is called with the
+            results of the ``authenticate()`` call when authentication fails. This will
+            only be called if the backend was deemed appropriate for the request
+            (ie. a ``falcon.HTTPUnauthorized`` exception was raised and not a
+            ``BackendNotApplicable`` exception).
+
+            .. code:: python
+
+                def on_failure(req, resp, resource, exception):
+                    ...
     """
 
-    def __init__(self, backend, exempt_routes=None, exempt_methods=None, context_key='auth'):
+    def __init__(self, backend, exempt_routes=None, exempt_methods=None, context_key='auth',
+                 on_success=None, on_failure=None):
         self.backend = backend
+        self.on_success = on_success
+        self.on_failure = on_failure
+
         if not isinstance(backend, AuthBackend):
             raise ValueError(
                 (
                     'Invalid authentication backend {0}.'
                     ' Must inherit falcon.auth.backends.AuthBackend'
                 ).format(backend.__class__.__name__)
-            )
-
-        try:
-            backend.AUTH_TYPE
-        except AttributeError:
-            raise ValueError(
-                (
-                    'Invalid authentication backend {0}.'
-                    ' Must define AUTH_TYPE.'
-                )
-                .format(backend.__class__.__name__)
             )
 
         self.exempt_routes = exempt_routes or []
@@ -79,6 +90,30 @@ class FalconAuthMiddleware(object):
             return
 
         backend = auth_setting['backend']
-        results = backend.authenticate(req, resp, resource, **kwargs)
-        results.setdefault('type', backend.AUTH_TYPE)
-        req.context[self.context_key] = results
+        try:
+            results = backend.authenticate(req, resp, resource, **kwargs)
+            # Use setdefault() here to accommodate MultiAuthBackend that
+            # sets this value to the successful backend type in its list.
+            results.setdefault('backend', backend)
+            req.context[self.context_key] = results
+            if self.on_success:
+                self.on_success(req, resp, resource, results)
+        except BackendAuthenticationFailure as ex:
+            if self.on_failure:
+                # Notify the application about the failure and the backend
+                # that raised it before re-raising it.
+                self.on_failure(req, resp, resource, ex)
+            raise
+        except Exception as ex:
+            if self.on_failure:
+                # As we wish to convey which backend was responsible for
+                # the authentication failure, we wrap any
+                # non-BackendAuthenticationFailure exceptions in one and
+                # provide that to the application. The original exception
+                # will be re-raised.
+                backend_auth_failure = BackendAuthenticationFailure(
+                    backend,
+                    'Unexpected authentication error')
+                backend_auth_failure.__cause__ = ex
+                self.on_failure(req, resp, resource, backend_auth_failure)
+            raise

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import sys
 from setuptools import setup
 
-version = '2.0.1'
+version = '3.0.0'
 
 if sys.argv[-1] == 'tag':
     os.system("git tag -a %s -m 'version %s'" % (version, version))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ def create_app(auth_middleware, resource):
 class AuthResource:
 
     def on_post(self, req, resp):
-        user = req.context['user']
+        user = req.context['auth']['user']
         resp.body = user.serialize()
 
     def on_get(self, req, resp, **kwargs):
@@ -255,6 +255,9 @@ class CustomException(Exception):
 
 class MultiBackendAuthFixture:
     class ErrorBackend(AuthBackend):
+
+        AUTH_TYPE = 'error'
+
         def __init__(self, user_loader=None):
             pass
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -336,7 +336,7 @@ class TestWithResourceExemptMethod(BasicAuthFixture, ResourceExemptGet):
         assert resp.text == 'Success'
 
 
-def test_auth_middleware_invalid_backend():
+def test_auth_middleware_invalid_backend_type():
     class A(object):
         pass
 
@@ -344,6 +344,19 @@ def test_auth_middleware_invalid_backend():
         FalconAuthMiddleware(backend=A())
 
     assert 'Invalid authentication backend' in str(ex.value)
+    assert 'Must inherit falcon.auth.backends.AuthBackend' in str(ex.value)
+
+
+def test_auth_middleware_invalid_backend_missing_auth_type():
+    class A(AuthBackend):
+        def __init__(self):
+            pass
+
+    with pytest.raises(ValueError) as ex:
+        FalconAuthMiddleware(backend=A())
+
+    assert 'Invalid authentication backend' in str(ex.value)
+    assert 'Must define AUTH_TYPE' in str(ex.value)
 
 
 def test_auth_middleware_none_backend():


### PR DESCRIPTION
### [Breaking Changes] Augmented results from the backend authentication
This updates the backend interface to allow backends to return more than just the `user` object.
Some backends, like the `HawkAuthBackend` backend, do more than just authentication. They
can extract extra information from the `Authorization` header that may be of importance to the
request.

Now the result of a successful authentication will be provided to the `req` object as follows:

```
        # Hawk auth example
        req.context['auth'] = {
                'backend': <backend object that handled authentication>,
                'user': <user object returned from user_loader()>,
                'receiver': <the mohawk Receiver object used to authenticate the request>,
        }
```

Related to these changes, you can now specify the key to use in the `req.context` dictionary
by providing `context_key` to the middleware constructor. The default value is `'auth'`, as
seen above.

### [Breaking Changes] Custom backends need to be updated to the new interface
Anyone writing their own backends will need to make the following changes:
- Take care to call the base class `AuthBackend.__init__(user_loader)` from their `__init__()`
  method
- Return a dictionary from `authenticate()` which includes at least the `'user'` key
- Raise a `BackendNotApplicable` exception if the backend determines that it is not
  equipped to handle the request and should defer to a more appropriate backend.
- Prefer raising a `BackendAuthenticationFailure` in all other cases.

### Adding support for on_success() and on_failure() callbacks
This allows one to provide callbacks to the middleware that will be invoked upon success or
failure to authenticate. This is to allow the application to have more insight into the inner
workings of the auth process (read: logging).

If you are using a `MultiAuthBackend` and wish to determine which backend failed the
authentication, the `exception` argument to the `on_failure()` call will have a `backend`
property referencing the backend in question. It is possible that this is the `MultiAuthBackend`
itself, if none of the contained backends chose to authenticate the request.