### PR TITLE
Major refactor and update to middleware, MultiAuth and HawkAuth backends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,16 +37,30 @@ user to the ``request context``
 
     user_loader = lambda username, password: { 'username': username }
     auth_backend = BasicAuthBackend(user_loader)
-    auth_middleware = FalconAuthMiddleware(auth_backend,
-                        exempt_routes=['/exempt'], exempt_methods=['HEAD'])
+    auth_middleware = FalconAuthMiddleware(
+        auth_backend,
+        exempt_routes=['/exempt'],
+        exempt_methods=['HEAD'],
+        context_key='auth')
     api = falcon.API(middleware=[auth_middleware])
 
     class ApiResource:
 
         def on_post(self, req, resp):
-            user = req.context['user']
+            # req.context['auth'] is of the form:
+            #
+            #   {
+            #       'backend': <backend instance that performed the authentication>,
+            #       'user': <user object retrieved from user_loader()>,
+            #       '<backend specific item>': <some extra data from the backend>,
+            #       ...
+            #   }
+            user = req.context['auth']['user']
             resp.body = "User Found: {}".format(user['username'])
 
+If you wish to place the authentication results under a name other than ``'auth'``
+in the ``req.context``, provide the ``context_key`` argument to the middleware
+constructor.
 
 Override Authentication for a specific resource
 -----------------------------------------------
@@ -101,19 +115,38 @@ Disable Authentication for a specific resource
         }
 
 
-Accessing Authenticated User
+Accessing Authenticated User (and other artifacts)
 ----------------------------
-Once the middleware authenticates
-the request using the specified authentication backend, it add the authenticated
-user to the `request context`
+Once the middleware authenticates the request using the specified authentication
+backend, it adds the authenticated user to the `request context`.
 
 .. code:: python
 
     class ApiResource:
 
         def on_post(self, req, resp):
-            user = req.context['user']
+            # req.context['auth'] is of the form:
+            #
+            #   {
+            #       'backend': <backend instance that performed the authentication>,
+            #       'user': <user object retrieved from user_loader()>,
+            #       '<backend specific item>': <some extra data from the backend>,
+            #       ...
+            #   }
+            user = req.context['auth']['user']
             resp.body = "User Found: {}".format(user['username'])
+
+Be notified of success or failure to authenticate
+-------------------------------------------------
+
+The middleware accepts ``on_success`` and ``on_failure`` callbacks to be invoked upon the
+completion of the authentication process for a request. They both receive the standard
+falcon request, response and resource objects. The ``on_success`` callback will also receive
+the results of the authentication (augmented with the ``AuthBackend`` that authenticated the
+user). The ``on_failure`` callback will instead receive a ``BackendAuthenticationFailure``
+exception to indicate the reason for the failure. These exceptions will always have a
+``backend`` reference to indicate which backend failed the authentication (or a
+``MultiAuthBackend`` if all nested authentications failed).
 
 Authentication Backends
 -----------------------
@@ -132,7 +165,8 @@ header contains a prefix (typically Token) followed by an `API Token`
 + **JWT Authentication (Python 2.7, 3.4+)**
 
 Token based authentication using the `JSON Web Token standard <https://jwt.io/introduction/>`__
-If you wish to use this backend, be sure to add the optional dependency to your requirements (See Python `"extras" <https://www.python.org/dev/peps/pep-0508/#extras>`__):
+If you wish to use this backend, be sure to add the optional dependency to your requirements
+(See Python `"extras" <https://www.python.org/dev/peps/pep-0508/#extras>`__):
 
 .. code:: text
 
@@ -142,12 +176,15 @@ If you wish to use this backend, be sure to add the optional dependency to your 
 + **Hawk Authentication (Python 2.6+, 3.4+)**
 
 Token based authentication using the `Hawk "Holder-Of-Key Authentication Scheme" <https://github.com/hueniverse/hawk>`__
-If you wish to use this backend, be sure to add the optional dependency to your requirements (See Python `"extras" <https://www.python.org/dev/peps/pep-0508/#extras>`__):
+If you wish to use this backend, be sure to add the optional dependency to your requirements
+(See Python `"extras" <https://www.python.org/dev/peps/pep-0508/#extras>`__):
 
 .. code:: text
 
     falcon-auth[backend-hawk]
 
+This backend will also provide the ``mohawk.Receiver`` object in the ``req.context['auth']``
+result under the 'receiver' key.
 
 + **Dummy Authentication**
 
@@ -155,8 +192,44 @@ Backend which does not perform any authentication checks
 
 + **Multi Backend Authentication**
 
-A Backend which comprises of multiple backends and requires any of them to authenticate
-the request successfully.
+An ``AuthBackend`` which is comprised of multiple backends and requires any of them to
+authenticate the request successfully.
+
+This backend will iterate over all provided backends until one of the following occurs:
+
+- A backend returns a successful authentication result, containing at least the user object
+- A backend raises a non-``BackendNotApplicable`` ``BackendAuthenticationFailure`` exception
+  and ``early_exit`` is true.
+- The end of the list is reached
+
+The ``BackendNotApplicable`` exception should be raised by a backend when it determines
+that it is not the appropriate backend to handle the request. (eg. The ``BasicAuthBackend``
+doesn't know how to parse a ``Hawk`` authorization header). In this way, a list of
+backends can short-circuit when an appropriate backend is found, rather than traversing
+the whole list. Any other exceptions will result in authentication stopping, the optional
+``on_failure()`` callback being invoked, and the exception propagating out of the
+middleware to be handled by the falcon framework. Any `WWW-Authenticate` challenges provided
+by the backends will be collected and sent back to the client.
+
+Custom Backends
+---------------
+
+It is expected that users will want to write their own backends to work with this middleware.
+Here are the guidelines to follow when writing your backend:
+
+- Inherit from `AuthBackend`.
+- Take care to call the base class ``AuthBackend.__init__(user_loader)`` from your `__init__()`
+  method.
+- Call ``AuthBackend.load_user()`` to invoke the provided ``user_loader`` callback and retrieve
+  the user object.
+- Return a dictionary from `authenticate()` which includes at least the `'user'` key holding
+  the user object returned from ``user_loader()``. Other backend-specific items can be included
+  as well.
+- Raise a `BackendNotApplicable` exception if the backend determines that it is not
+  equipped to handle the request and should defer to a more appropriate backend.
+- Prefer raising a `BackendAuthenticationFailure` in all other cases to potentially take
+  advantage of the ``MultiAuthBackend`` ``early_exit`` short-circuiting.
+
 
 Tests
 -----
@@ -164,7 +237,9 @@ Tests
 This library comes with a good set of tests which are included in ``tests/``. To run
 install ``pytest`` and simply invoke ``py.test`` or ``python setup.py test``
 to exercise the tests. You can check the test coverage by running
-``py.test --cov falcon_auth``
+``py.test --cov falcon_auth``. **Note:** The test suite makes use of pytest functionality
+that was deprecated in pytest==4.0.0, so be sure to run tests in an environment that
+uses a prior version.
 
 API
 ----
@@ -178,6 +253,9 @@ API
     :members:
 
 .. autoclass:: falcon_auth.JWTAuthBackend
+    :members:
+
+.. autoclass:: falcon_auth.HawkAuthBackend
     :members:
 
 .. autoclass:: falcon_auth.NoneAuthBackend

--- a/falcon_auth/middleware.py
+++ b/falcon_auth/middleware.py
@@ -5,21 +5,21 @@ from __future__ import division
 
 import falcon
 
-from falcon_auth.backends import AuthBackend
+from falcon_auth.backends import AuthBackend, BackendAuthenticationFailure
 
 
 class FalconAuthMiddleware(object):
 
     """
     Creates a falcon auth middleware that uses given authentication backend, and some
-    optinal configuration to authenticate requests. After initializing the
+    optional configuration to authenticate requests. After initializing the
     authentication backend globally you can override the backend as well as
-    other configuration for a particular  resource by setting the `auth` attribute
+    other configuration for a particular resource by setting the `auth` attribute
     on it to an instance of this class.
 
     The authentication backend must return an authenticated user which is then
-    set as `request.context.user` to be used further down by resources othewise
-    an `falcon.HTTPUnauthorized` exception is raised.
+    set as ``request.context['auth']['user']`` to be used further down by resources
+    othewise an ``falcon.HTTPUnauthorized`` exception is raised.
 
     Args:
         backend(:class:`falcon_auth.backends.AuthBackend`, required): Specifies the auth
@@ -31,18 +31,46 @@ class FalconAuthMiddleware(object):
         exempt_methods(list, optional): A list of paths to be excluded while performing
             authentication. Default is ``['OPTIONS']``
 
+        context_key(str, optional): The key to be used when adding the successful
+            authentication results to the ``req.context`` dictionary. Default is ``'auth'``.
+
+        on_success(function, optional): A callback function that is called with the
+            results of the ``authenticate()`` call when authentication succeeds.
+
+            .. code:: python
+
+                def on_success(req, resp, resource, results):
+                    ...
+
+        on_failure(function, optional): A callback function that is called with the
+            results of the ``authenticate()`` call when authentication fails. This will
+            only be called if the backend was deemed appropriate for the request
+            (ie. a ``falcon.HTTPUnauthorized`` exception was raised and not a
+            ``BackendNotApplicable`` exception).
+
+            .. code:: python
+
+                def on_failure(req, resp, resource, exception):
+                    ...
     """
 
-    def __init__(self, backend, exempt_routes=None, exempt_methods=None):
+    def __init__(self, backend, exempt_routes=None, exempt_methods=None, context_key='auth',
+                 on_success=None, on_failure=None):
         self.backend = backend
+        self.on_success = on_success
+        self.on_failure = on_failure
+
         if not isinstance(backend, AuthBackend):
             raise ValueError(
-                'Invalid authentication backend {0}. '
-                'Must inherit `falcon.auth.backends.AuthBackend`'.format(backend)
+                (
+                    'Invalid authentication backend {0}.'
+                    ' Must inherit falcon.auth.backends.AuthBackend'
+                ).format(backend.__class__.__name__)
             )
 
         self.exempt_routes = exempt_routes or []
         self.exempt_methods = exempt_methods or ['OPTIONS']
+        self.context_key = context_key
 
     def _get_auth_settings(self, req, resource):
         auth_settings = getattr(resource, 'auth', {})
@@ -62,4 +90,32 @@ class FalconAuthMiddleware(object):
             return
 
         backend = auth_setting['backend']
-        req.context['user'] = backend.authenticate(req, resp, resource, **kwargs)
+        try:
+            results = backend.authenticate(req, resp, resource, **kwargs)
+            # Use setdefault() here to accommodate MultiAuthBackend that
+            # sets this value to the successful backend type in its list.
+            results.setdefault('backend', backend)
+            req.context[self.context_key] = results
+            if self.on_success:
+                self.on_success(req, resp, resource, results)
+
+        except BackendAuthenticationFailure as ex:
+            if self.on_failure:
+                # Notify the application about the failure and the backend
+                # that raised it before re-raising it.
+                self.on_failure(req, resp, resource, ex)
+            raise
+
+        except Exception as ex:
+            if self.on_failure:
+                # As we wish to convey which backend was responsible for
+                # the authentication failure, we wrap any
+                # non-BackendAuthenticationFailure exceptions in one and
+                # provide that to the application. The original exception
+                # will be re-raised.
+                backend_auth_failure = BackendAuthenticationFailure(
+                    backend,
+                    'Unexpected authentication error')
+                backend_auth_failure.__cause__ = ex
+                self.on_failure(req, resp, resource, backend_auth_failure)
+            raise

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,6 @@ description-file = README.md
 test = pytest
 
 [tool:pytest]
+; addopts = --pdb
 ; addopts = --pdb -x
+; addopts = --pdb -x tests/test_auth.py::TestWithMultiBackendAuth::test_invalid_auth_fails

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import sys
 from setuptools import setup
 
-version = '2.0.1'
+version = '3.0.0'
 
 if sys.argv[-1] == 'tag':
     os.system("git tag -a %s -m 'version %s'" % (version, version))
@@ -27,7 +27,7 @@ if sys.argv[-1] == 'test':
         modules = map(__import__, test_requirements)
     except ImportError as e:
         err_msg = e.message.replace("No module named ", "")
-        msg = "%s is not installed. Install your test requirments." % err_msg
+        msg = "%s is not installed. Install your test requirements." % err_msg
         raise ImportError(msg)
     os.system('py.test')
     sys.exit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,10 @@ import falcon
 import pytest
 from falcon import testing
 
-from falcon_auth.backends import AuthBackend, BasicAuthBackend, \
-    JWTAuthBackend, NoneAuthBackend, MultiAuthBackend, HawkAuthBackend
+from falcon_auth.backends import AuthBackend, BasicAuthBackend, TokenAuthBackend, \
+    JWTAuthBackend, NoneAuthBackend, MultiAuthBackend, HawkAuthBackend, \
+    BackendAuthenticationFailure, BackendNotApplicable, UserNotFound
 from falcon_auth.middleware import FalconAuthMiddleware
-from falcon_auth.backends import TokenAuthBackend
 from falcon_auth.serializer import ExtendedJSONEncoder
 
 try:
@@ -84,7 +84,7 @@ def create_app(auth_middleware, resource):
 class AuthResource:
 
     def on_post(self, req, resp):
-        user = req.context['user']
+        user = req.context['auth']['user']
         resp.body = user.serialize()
 
     def on_get(self, req, resp, **kwargs):
@@ -192,26 +192,28 @@ class JWTAuthFixture:
 @pytest.fixture(scope='function')
 def hawk_backend(user):
     def user_loader(username):
-        return user if user.username == username else None
-
-    def credentials_map(username):
         # Our backend will only know about the one user
         creds = {
-            user.username: {
-                'id': user.username,
-                'key': user.password,
-                'algorithm': 'sha256',
-            }
+            user.username: user,
         }
 
-        return creds[username]
+        return creds.get(username)
+
+    def credentials_loader(user):
+        return {
+            'id': user.username,
+            'key': user.password,
+            'algorithm': 'sha256',
+        }
 
     return HawkAuthBackend(
-        user_loader,
-        receiver_kwargs=dict(credentials_map=credentials_map))
+        user_loader=user_loader,
+        credentials_loader=credentials_loader,
+        receiver_kwargs=dict(),
+    )
 
 
-def get_hawk_token(user):
+def get_hawk_token(user, timestamp=None):
     sender = mohawk.Sender(
         credentials={
             'id': user.username,
@@ -221,7 +223,8 @@ def get_hawk_token(user):
         url='http://falconframework.org/auth',
         method='GET',
         nonce='ABC123',
-        always_hash_content=False
+        always_hash_content=False,
+        _timestamp=timestamp,
     )
     return str(sender.request_header)
 
@@ -255,23 +258,37 @@ class CustomException(Exception):
 
 class MultiBackendAuthFixture:
     class ErrorBackend(AuthBackend):
-        def __init__(self, user_loader=None):
-            pass
 
         def authenticate(self, req, resp, resource):
-            if req.get_param_as_bool('exception'):
+            if req.get_param('exception') == 'custom':
                 raise CustomException
-            else:
+            elif req.get_param('exception') == 'unauthorized':
                 raise falcon.HTTPUnauthorized
+            else:
+                raise BackendNotApplicable(self)
 
     @pytest.fixture(scope='function')
     def backend(self, basic_auth_backend, token_backend, hawk_backend, jwt_backend):
         return MultiAuthBackend(
-            self.ErrorBackend(),
+            self.ErrorBackend(None),
             basic_auth_backend,
             token_backend,
             hawk_backend,
             jwt_backend,
+        )
+
+
+class EarlyExitMultiBackendAuthFixture(MultiBackendAuthFixture):
+
+    @pytest.fixture(scope='function')
+    def backend(self, basic_auth_backend, token_backend, hawk_backend, jwt_backend):
+        return MultiAuthBackend(
+            self.ErrorBackend(None),
+            basic_auth_backend,
+            token_backend,
+            hawk_backend,
+            jwt_backend,
+            early_exit=True,
         )
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 
+import time
 from tests.conftest import *
 
 
@@ -50,7 +51,7 @@ class TestWithBasicAuth(BasicAuthFixture, ResourceFixture):
         auth_token = get_basic_auth_token('invalid', user.password)
         resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 401
-        assert 'Invalid Username/Password' in resp.text
+        assert 'User not found for provided credentials' in resp.text
 
     def test_valid_auth_custom_prefix_success(self, client,
                                                  backend, user):
@@ -64,6 +65,49 @@ class TestWithBasicAuth(BasicAuthFixture, ResourceFixture):
     def test_backend_get_auth_token(self, user, backend, auth_token):
         user_payload = {'username': user.username, 'password': user.password}
         assert backend.get_auth_token(user_payload) == auth_token
+
+    def test_on_success_callback(self, user, backend, resource, auth_token):
+        callback_called = [False]
+
+        def on_success(req, resp, resrc, results):
+            callback_called[0] = True
+            assert results['backend'] is backend
+            assert results['user'] is user
+
+        app = create_app(FalconAuthMiddleware(backend, on_success=on_success), resource)
+        client = testing.TestClient(app)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 200
+        assert callback_called[0], 'on_success() not called'
+
+    def test_on_failure_callback(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_failure(req, resp, resrc, exception):
+            callback_called[0] = True
+            assert isinstance(exception, BackendAuthenticationFailure)
+            assert not hasattr(exception, '__cause__') or not exception.__cause__
+
+        app = create_app(FalconAuthMiddleware(backend, on_failure=on_failure), resource)
+        client = testing.TestClient(app)
+        auth_token = get_basic_auth_token('invalid', user.password)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 401
+        assert callback_called[0], 'on_failure() not called'
+
+    def test_on_failure_callback_called_even_if_not_applicable(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_failure(req, resp, resrc, exception):
+            callback_called[0] = True
+            assert isinstance(exception, BackendNotApplicable)
+
+        app = create_app(FalconAuthMiddleware(backend, on_failure=on_failure), resource)
+        client = testing.TestClient(app)
+        auth_token = get_token_auth(user)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 401
+        assert callback_called[0], 'on_failure() not called'
 
 
 class TestWithTokenAuth(TokenAuthFixture, ResourceFixture):
@@ -89,7 +133,7 @@ class TestWithTokenAuth(TokenAuthFixture, ResourceFixture):
         auth_token = 'Token InvalidToken'
         resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 401
-        assert 'Invalid Token' in resp.text
+        assert 'User not found for provided credentials' in resp.text
 
     def test_valid_auth_custom_prefix_success(self, client,
                                               backend, user):
@@ -103,6 +147,34 @@ class TestWithTokenAuth(TokenAuthFixture, ResourceFixture):
     def test_backend_get_auth_token(self, user, backend, auth_token):
         user_payload = {'token': user.token}
         assert backend.get_auth_token(user_payload) == auth_token
+
+    def test_on_success_callback(self, user, backend, resource, auth_token):
+        callback_called = [False]
+
+        def on_success(req, resp, resrc, results):
+            callback_called[0] = True
+            assert results['backend'] is backend
+            assert results['user'] is user
+
+        app = create_app(FalconAuthMiddleware(backend, on_success=on_success), resource)
+        client = testing.TestClient(app)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 200
+        assert callback_called[0], 'on_success() not called'
+
+    def test_on_failure_callback(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_failure(req, resp, resrc, exception):
+            callback_called[0] = True
+            assert isinstance(exception, UserNotFound)
+
+        app = create_app(FalconAuthMiddleware(backend, on_failure=on_failure), resource)
+        client = testing.TestClient(app)
+        auth_token = 'Token InvalidToken'
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 401
+        assert callback_called[0], 'on_failure() not called'
 
 
 @jwt_available
@@ -130,7 +202,7 @@ class TestWithJWTAuth(JWTAuthFixture, ResourceFixture):
         auth_token = get_jwt_token(cloned_user)
         resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 401
-        assert 'Invalid JWT Credentials' in resp.text
+        assert 'User not found for provided credentials' in resp.text
 
     def test_valid_auth_custom_prefix_success(self, client,
                                               backend, user, auth_token):
@@ -181,6 +253,36 @@ class TestWithJWTAuth(JWTAuthFixture, ResourceFixture):
         decoded_token = jwt.decode(auth_token, SECRET_KEY)
         assert decoded_token['user'] == user_payload
 
+    def test_on_success_callback(self, user, backend, resource, auth_token):
+        callback_called = [False]
+
+        def on_success(req, resp, resrc, results):
+            callback_called[0] = True
+            assert results['backend'] is backend
+            assert results['user'] is user
+
+        app = create_app(FalconAuthMiddleware(backend, on_success=on_success), resource)
+        client = testing.TestClient(app)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 200
+        assert callback_called[0], 'on_success() not called'
+
+    def test_on_failure_callback(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_failure(req, resp, resrc, exception):
+            callback_called[0] = True
+            assert isinstance(exception, UserNotFound)
+
+        app = create_app(FalconAuthMiddleware(backend, on_failure=on_failure), resource)
+        client = testing.TestClient(app)
+        cloned_user = user.clone()
+        cloned_user.id = user.id + 1
+        auth_token = get_jwt_token(cloned_user)
+        resp = simulate_request(client, '/auth', auth_token=auth_token)
+        assert resp.status_code == 401
+        assert callback_called[0], 'on_failure() not called'
+
 
 @hawk_available
 class TestWithHawkAuth(HawkAuthFixture, ResourceFixture):
@@ -202,8 +304,7 @@ class TestWithHawkAuth(HawkAuthFixture, ResourceFixture):
         auth_token = get_hawk_token(cloned_user)
         resp = simulate_request(client, '/auth', method='GET', auth_token=auth_token)
         assert resp.status_code == 401
-        assert (resp.json['description']
-                == 'CredentialsLookupError(Could not find credentials for ID jane)')
+        assert resp.json['description'] == 'User not found for provided credentials'
 
     def test_invalid_password_fails(self, client, user):
         cloned_user = user.clone()
@@ -213,9 +314,36 @@ class TestWithHawkAuth(HawkAuthFixture, ResourceFixture):
         assert resp.status_code == 401
         assert 'MacMismatch(MACs do not match' in resp.json['description']
 
-    def test_init_receiver_credentials_map_none_fails(self):
-        with pytest.raises(ValueError) as ex:
-            HawkAuthBackend(lambda u: u, receiver_kwargs={})
+    def test_on_success_callback(self, user, backend, resource, auth_token):
+        callback_called = [False]
+
+        def on_success(req, resp, resrc, results):
+            callback_called[0] = True
+            assert results['backend'] is backend
+            assert results['user'] is user
+
+        app = create_app(FalconAuthMiddleware(backend, on_success=on_success), resource)
+        client = testing.TestClient(app)
+        resp = simulate_request(client, '/auth', method='GET', auth_token=auth_token)
+        assert resp.status_code == 200
+        assert callback_called[0], 'on_success() not called'
+
+    def test_on_failure_callback(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_failure(req, resp, resrc, exception):
+            callback_called[0] = True
+            assert isinstance(exception, falcon.HTTPUnauthorized)
+            assert not isinstance(exception, BackendNotApplicable)
+
+        app = create_app(FalconAuthMiddleware(backend, on_failure=on_failure), resource)
+        client = testing.TestClient(app)
+        cloned_user = user.clone()
+        cloned_user.password = 'incorrect password'
+        auth_token = get_hawk_token(cloned_user)
+        resp = simulate_request(client, '/auth', method='GET', auth_token=auth_token)
+        assert resp.status_code == 401
+        assert callback_called[0], 'on_failure() not called'
 
 
 class TestWithNoneAuth(NoneAuthFixture, ResourceFixture):
@@ -225,48 +353,128 @@ class TestWithNoneAuth(NoneAuthFixture, ResourceFixture):
         assert resp.status_code == 200
         assert resp.json == none_user.to_dict()
 
+
 @hawk_available
 @jwt_available
 class TestWithMultiBackendAuth(MultiBackendAuthFixture, ResourceFixture):
-    def test_valid_auth_success_basic_backend(self, client, user):
+    def test_valid_auth_success_basic_backend(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_success(req, resp, resrc, results):
+            callback_called[0] = True
+            assert isinstance(results['backend'], BasicAuthBackend)
+            assert results['user'] is user
+
+        app = create_app(FalconAuthMiddleware(backend, on_success=on_success), resource)
+        client = testing.TestClient(app)
         auth_token = get_basic_auth_token(user.username, user.password)
         resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 200
         assert resp.json == user.to_dict()
+        assert callback_called[0], 'on_success() not called'
 
-    def test_valid_auth_success_token_backend(self, client, user):
+    def test_valid_auth_success_token_backend(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_success(req, resp, resrc, results):
+            callback_called[0] = True
+            assert isinstance(results['backend'], TokenAuthBackend)
+            assert results['user'] is user
+
+        app = create_app(FalconAuthMiddleware(backend, on_success=on_success), resource)
+        client = testing.TestClient(app)
         auth_token = get_token_auth(user)
         resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 200
         assert resp.json == user.to_dict()
+        assert callback_called[0], 'on_success() not called'
 
-    def test_valid_auth_success_hawk_backend(self, client, user):
+    def test_valid_auth_success_hawk_backend(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_success(req, resp, resrc, results):
+            callback_called[0] = True
+            assert isinstance(results['backend'], HawkAuthBackend)
+            assert results['user'] is user
+            assert 'receiver' in results
+
+        app = create_app(FalconAuthMiddleware(backend, on_success=on_success), resource)
+        client = testing.TestClient(app)
         auth_token = get_hawk_token(user)
         resp = simulate_request(client, '/auth', method='GET', auth_token=auth_token)
         assert resp.status_code == 200
+        assert callback_called[0], 'on_success() not called'
 
-    def test_valid_auth_success_jwt_backend(self, client, user):
+    def test_valid_auth_success_jwt_backend(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_success(req, resp, resrc, results):
+            callback_called[0] = True
+            assert isinstance(results['backend'], JWTAuthBackend)
+            assert results['user'] is user
+
+        app = create_app(FalconAuthMiddleware(backend, on_success=on_success), resource)
+        client = testing.TestClient(app)
         auth_token = get_jwt_token(user)
         resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 200
         assert resp.json == user.to_dict()
+        assert callback_called[0], 'on_success() not called'
 
     def test_invalid_auth_fails(self, client, user):
         auth_token = get_basic_auth_token('Invalid', 'Invalid')
         resp = simulate_request(client, '/auth', auth_token=auth_token)
         assert resp.status_code == 401
-        assert 'Authorization Failed' in resp.text
+        assert resp.json['description'] == 'Authentication Failed'
 
     def test_backend_get_auth_token(self, user, backend):
         auth_token = get_basic_auth_token(user.username, user.password)
         user_payload = {'username': user.username, 'password': user.password}
         assert backend.get_auth_token(user_payload) == auth_token
 
-    def test_backend_raises_exception(self, client, user, backend):
+    def test_backend_raises_unexpected_exception(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_failure(req, resp, resrc, exception):
+            callback_called[0] = True
+            assert isinstance(exception, BackendAuthenticationFailure)
+            assert isinstance(exception.__cause__, CustomException)
+            assert exception.backend is backend
+
+        app = create_app(FalconAuthMiddleware(backend, on_failure=on_failure), resource)
+        client = testing.TestClient(app)
         auth_token = get_basic_auth_token('Invalid', 'Invalid')
         with pytest.raises(CustomException):
-            resp = simulate_request(client, '/auth', auth_token=auth_token,
-                                    query_string='exception=True')
+            simulate_request(client, '/auth', auth_token=auth_token,
+                             query_string='exception=custom')
+        assert callback_called[0], 'on_failure() not called'
+
+    def test_backend_raises_expected_exception(self, client, user, backend):
+        auth_token = get_basic_auth_token('Invalid', 'Invalid')
+        resp = simulate_request(client, '/auth', auth_token=auth_token,
+                                query_string='exception=unauthorized')
+        assert resp.status_code == 401
+
+
+class TestWithEarlyExitMultiAuthBackend(EarlyExitMultiBackendAuthFixture, ResourceFixture):
+
+    def test_invalid_auth_fails_and_exits(self, user, backend, resource):
+        callback_called = [False]
+
+        def on_failure(req, resp, resrc, exception):
+            callback_called[0] = True
+            assert isinstance(exception, BackendAuthenticationFailure)
+            assert isinstance(exception.backend, HawkAuthBackend)
+
+        app = create_app(FalconAuthMiddleware(backend, on_failure=on_failure), resource)
+        client = testing.TestClient(app)
+        auth_token = get_hawk_token(user, timestamp=int(time.time()) + 3600)
+        resp = simulate_request(client, '/auth', method='GET', auth_token=auth_token)
+        assert resp.status_code == 401
+        assert 'TokenExpired' in resp.json['description']
+        assert callback_called[0], 'on_failure() not called'
+
+
 
 
 class TestWithExemptRoute(BasicAuthFixture, ResourceFixture):
@@ -336,7 +544,7 @@ class TestWithResourceExemptMethod(BasicAuthFixture, ResourceExemptGet):
         assert resp.text == 'Success'
 
 
-def test_auth_middleware_invalid_backend():
+def test_auth_middleware_invalid_backend_type():
     class A(object):
         pass
 
@@ -344,6 +552,7 @@ def test_auth_middleware_invalid_backend():
         FalconAuthMiddleware(backend=A())
 
     assert 'Invalid authentication backend' in str(ex.value)
+    assert 'Must inherit falcon.auth.backends.AuthBackend' in str(ex.value)
 
 
 def test_auth_middleware_none_backend():
@@ -364,4 +573,4 @@ def test_optional_jwt_not_present(monkeypatch):
 def test_optional_hawk_not_present(monkeypatch):
     monkeypatch.delattr('falcon_auth.backends.mohawk')
     with pytest.raises(ImportError):
-        HawkAuthBackend(lambda _: None, {})
+        HawkAuthBackend(lambda _: None, lambda _: None, {})


### PR DESCRIPTION
Breaking Changes
==================

Changes to authenticate() return value
-------------------------------------

This updates the backend interface to allow backends to return more than just the `user` object.
Some backends, like the Hawk backend, do more than just authentication. They can extract extra
information from the `Authorization` header that may be of importance to the request.

So now, the result of a successful authentication will be provided to the `req` object as follows:

```
	# Hawk auth example
	req.context['auth'] = {
		# Always present
		'backend': <the backend instance that authenticated the user>,
		'user': <user object returned from user_loader()>,

		# Backend-specific, if provided by backend
		'receiver': <the Hawk Receiver object used to authenticate the request>,
	}
```

Notice that the `'user'` key is nested one level deeper under the `'auth'` dictionary. A user of
this library can now specify the key to hold the authentication results in the `req.context`
dictionary. The default value is `'auth'`, as seen above.

Anyone writing their own backends will need to modify their backend's `authenticate()` method to
return a dictionary like the above format which includes at least the `'user'` key.

Changes to authenticate() semantics
-----------------------------------

Custom `authenthicate()` implementations should always either return a dictionary containing the
user object, or raise a `UserNotFound` exception. One can use the new `AuthBackend.load_user()`
method to accomplish this. It invokes the provided `user_loader` callback and raises a
`UserNotFound` exception if the user cannot be retrieved from the app. In this way, we can simplify
any `authenticate()` implementation by writing code that assumes the user has been found, as the
`UserNotFound` exception will be caught by the middleware.

Changes to HawkAuthBackend interface
--------------------------------------

The `HawkAuthBackend` now takes a second parameter `credentials_loader` which will receive the
retrieved user object and is expected to return the Hawk credentials map data. It is now an error to
provide the `credentials_map` value in the `receiver_kwargs` dictionary.

Changes to MultiAuthBackend
-----------------------------

There is a new parameter to the `MultiAuthBackend` constructor: `early_exit`. If true, the
`MultiAuthBackend` will stop iterating through its list of backends and exit with a failure to
authenticate if the current backend raises a non-`BackendNotApplicable`
`BackendAuthenticationFailure` exception. This is to allow a backend to "claim" the authentication
of a request and assert that it was able to examine the request and definitively say that the
credentials were invalid for the indicated user. Exceptions that will ignore the `early_exit`
setting and allow the `MultiAuthBackend` to continue iterating are:

- `UserNotFound`
- `BackendNotApplicable`
- Any other `falcon.HTTPUnauthorized` exception
- Any other `Exception` (though this will likely result in an end to iteration anyway as the
  exception bubbles up through the stack)

In situations where the `MultiAuthBackend` is allowed to iterate through the entire list of backends
without success, any challenges presented by those backends (in the form of the `WWW-Authenticate`
header on the `falcon.HTTPUnauthorized` exceptions) will still be collected and included in the
ultimate `falcon.HTTPUnauthorized` exception raised by the `MultiAuthBackend`.

Changes to error messages
-------------------------

Many error titles and descriptions have been updated for consistency and formatting. For instance,
"Invalid authentication backend" errors to no longer include backticks in the string.

Benign Changes
==============

Success/failure callbacks
-------------------------

Added support for `on_success()` and `on_failure()` callbacks

This allows one to provide callbacks to the middleware that will be invoked upon success or failure
to authenticate. This is to allow the application to have more insight into the inner workings of
the auth process (read: logging).

The `on_success` callback will receive the `req`, `resp`, `resource` and `results` parameters.
The `on_failure` callback will receive the `req`, `resp`, `resource` and `exception` parameters. The
`exception` parameter will be of type `BackendAuthenticationFailure` which contains information
about the backend that failed the authentication.