### PR TITLE
Use req.uri_template when disabling a resource

### DIFF
--- a/falcon_auth/middleware.py
+++ b/falcon_auth/middleware.py
@@ -48,7 +48,7 @@ class FalconAuthMiddleware(object):
         auth_settings = getattr(resource, 'auth', {})
         auth_settings['exempt_routes'] = self.exempt_routes
         if auth_settings.get('auth_disabled'):
-            auth_settings['exempt_routes'].append(req.path)
+            auth_settings['exempt_routes'].append(req.uri_template)
 
         for key in ('exempt_methods', 'backend'):
             auth_settings[key] = auth_settings.get(key) or getattr(self, key)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -322,8 +322,14 @@ class TestWithCustomResourceBackend(BasicAuthFixture, ResourceCustomBackend):
 
 class TestWithResourceAuthDisabled(BasicAuthFixture, ResourceAuthDisabled):
 
-    def test_auth_endpoint_no_auth_success(self, client):
+    def test_auth_endpoint_no_auth_success_on_simple_uri(self, client):
         resp = simulate_request(client, '/auth', method='GET')
+        assert resp.status_code == 200
+        assert resp.text == 'Success'
+
+
+    def test_auth_endpoint_no_auth_success_on_uri_template(self, client):
+        resp = simulate_request(client, '/posts/1234', method='GET')
         assert resp.status_code == 200
         assert resp.text == 'Success'
 


### PR DESCRIPTION
The logic used to disable the auth middleware for a resource does so by adding
the current request's path to the `exempt_routes` collection. This is a somewhat
indirect way of informing the middleware that the resource should not be
processed.

Incidentally, we introduced a bug in a recent commit when we began
using the `req.uri_template` rather than the rendered `req.path` when matching
`exempt_routes`. Unfortunately, we missed the usage in `_get_auth_settings()`
which contains the logic mentioned above.

This PR attempts to address this shortcoming and adds a test to cover this gap.