### PR TITLE
Remove Python 26,27,33 Test Env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,6 @@ language: python
 
 matrix:
   include:
-    - python: 2.6
-      env:
-        - WITH_JWT=false
-          WITH_HAWK=true
-    - python: 2.7
-      env:
-        - WITH_JWT=true
-          WITH_HAWK=true
-    - python: 3.3
-      env:
-        - WITH_JWT=false
-          WITH_HAWK=false
-          SETUPTOOLS="setuptools<40.0.0"
     - python: 3.4
       env:
         - WITH_JWT=true

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{26,27,33,34,35,36}
+	py{34,35,36}
 skip_missing_interpreters =
 	True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{26,27,33,34,35,36}
+	py{35,36}
 skip_missing_interpreters =
 	True
 


### PR DESCRIPTION
Since Falcon 2.0 is released support for python 3.3 downward is dropped. Python 3.4 is in deprecated status.