### PR TITLE
Bugfix jwt.encode AttributeError 

### DIFF
--- a/falcon_auth/backends.py
+++ b/falcon_auth/backends.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 import base64
 from datetime import timedelta, datetime
+from packaging import version
 
 import falcon
 
@@ -251,6 +252,12 @@ class JWTAuthBackend(AuthBackend):
         if self.issuer is not None:
             payload['iss'] = self.issuer
 
+        if version.parse(jwt.__version__).release[0] >= 2:
+            return jwt.encode(
+                payload,
+                self.secret_key,
+                algorithm=self.algorithm,
+                json_encoder=ExtendedJSONEncoder)
         return jwt.encode(
             payload,
             self.secret_key,

--- a/falcon_auth/backends.py
+++ b/falcon_auth/backends.py
@@ -5,9 +5,7 @@ from __future__ import division
 
 import base64
 from datetime import timedelta, datetime
-from packaging import version
 
-import platform
 import falcon
 
 try:
@@ -255,25 +253,18 @@ class JWTAuthBackend(AuthBackend):
 
         if self.issuer is not None:
             payload['iss'] = self.issuer
-
-        if version.parse(jwt.__version__).release[0] >= 2:
+        try:
+            return jwt.encode(
+                payload,
+                self.secret_key,
+                algorithm=self.algorithm,
+                json_encoder=ExtendedJSONEncoder).decode('utf-8')
+        except AttributeError:
             return jwt.encode(
                 payload,
                 self.secret_key,
                 algorithm=self.algorithm,
                 json_encoder=ExtendedJSONEncoder)
-
-        if tuple([int(i) for i in platform.python_version_tuple()[0:2]]) >= (3, 9):
-            return jwt.encode(
-                payload,
-                self.secret_key,
-                algorithm=self.algorithm,
-                json_encoder=ExtendedJSONEncoder)
-        return jwt.encode(
-            payload,
-            self.secret_key,
-            algorithm=self.algorithm,
-            json_encoder=ExtendedJSONEncoder).decode('utf-8')
 
 
 class BasicAuthBackend(AuthBackend):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     download_url='',
     setup_requires=setup_requires,
     install_requires=[
-        'falcon'
+        'falcon',
+        'packaging'
     ],
     extras_require={
         'backend-hawk': ['mohawk>=1.0.0,<2.0.0'],

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     setup_requires=setup_requires,
     install_requires=[
         'falcon',
-        'packaging'
     ],
     extras_require={
         'backend-hawk': ['mohawk>=1.0.0,<2.0.0'],


### PR DESCRIPTION
Hi 

In pyJWT 2.0.0 will get this error on using JWTAuthBackend.get_auth_token .

```python
  File "/usr/local/lib/python3.8/site-packages/falcon_auth/backends.py", line 244, in get_auth_token
    return jwt.encode(payload, self.secret_key,
AttributeError: 'str' object has no attribute 'decode'
```



jwt.encode return str after pyJWT2.0.0

so I try to fix it and support old pyJWT version.
or ... upgrade pyJWT dependency version ? 

---

on pyJWT 2.0.0

```python
>>> import jwt
>>> jwt.__version__
'2.0.0'
>>> jwt.encode({"some":"test"},"key", algorithm="HS256")
'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzb21lIjoidGVzdCJ9.dAcd-lcbrpkHbURDH1GZ0py-R5imIWAYSlT3FusC3ZU'
>>> type(jwt.encode({"some":"test"},"key", algorithm="HS256"))
<class 'str'>
```

on pyJWT 1.7.1

```python
>>> import jwt
>>> jwt.__version__
'1.7.1'
>>> jwt.encode({"some":"test"},"key", algorithm="HS256")
b'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzb21lIjoidGVzdCJ9.dAcd-lcbrpkHbURDH1GZ0py-R5imIWAYSlT3FusC3ZU'
>>> type(jwt.encode({"some":"test"},"key", algorithm="HS256"))
<class 'bytes'>
```

