### PR TITLE
fixing isoformat for date and time objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,12 @@ falcon-auth
 A falcon middleware + authentication backends that adds authentication layer
 to you app/api service.
 
+Notes
+------------
+
+This fork fixes a bug in what appears to be a project that is no longer maintained.
+The fork is being left up as a favor to a friend.
+
 Installation
 ------------
 

--- a/falcon_auth/serializer.py
+++ b/falcon_auth/serializer.py
@@ -18,7 +18,9 @@ class ExtendedJSONEncoder(json.JSONEncoder):
         * ``datetime.time``
     """
     def default(self, data):
-        if isinstance(data, (datetime.datetime, datetime.date, datetime.time)):
+        if isinstance(data, datetime.datetime):
             return data.isoformat('T')
+        elif isinstance(data, (datetime.date, datetime.time)):
+            return data.isoformat()
         else:
             return super(ExtendedJSONEncoder, self).default(data)


### PR DESCRIPTION
Solve the following:

```python
  File "[path]py/lib/python3.8/site-packages/falcon_auth/serializer.py", line 22, in default
    return data.isoformat('T')
TypeError: isoformat() takes no arguments (1 given)
```