### PR TITLE
updating BasicAuthBackend to accept a 'challenges' parameter

### DIFF
--- a/falcon_auth/backends.py
+++ b/falcon_auth/backends.py
@@ -278,13 +278,17 @@ class BasicAuthBackend(AuthBackend):
             bases64 encoded credentials in the `Authorization` header. Default is
             ``basic``
 
+        challenges(list, optional): A list of challenge strings to be set as
+            the WWW-Authenticate header when authentication fails.
     """
 
     def __init__(self, user_loader,
-                 auth_header_prefix='Basic'):
+                 auth_header_prefix='Basic',
+                 challenges=None):
 
         self.user_loader = user_loader
         self.auth_header_prefix = auth_header_prefix
+        self.challenges = challenges
 
     def _extract_credentials(self, req):
         auth = req.get_header('Authorization')
@@ -314,7 +318,8 @@ class BasicAuthBackend(AuthBackend):
         user = self.user_loader(username, password)
         if not user:
             raise falcon.HTTPUnauthorized(
-                description='Invalid Username/Password')
+                description='Invalid Username/Password',
+                challenges=self.challenges)
 
         return user
 


### PR DESCRIPTION
I needed this option to specify challenges on the BasicAuthBackend. There are other ways of ensuring a challenge is issued, including using a global catchall exception handler and re-wrapping the HTTPUnauthorized errors with the challenge parameter, but that is obviously messy. Since basic auth is most commonly used with challenges in the browser, I was surprised to find this wasn't already an option on the class.

This lets the user initialize their BasicAuthBackend like this:

```python
auth = BasicAuthBackend(user_loader=login_fn, challenges=["Basic"])
```

...and then the browser will correctly prompt the user for login.